### PR TITLE
Fix cursor reset

### DIFF
--- a/main.js
+++ b/main.js
@@ -47,6 +47,9 @@ const setText = (text) => {
 const displayText = (items) => {
   // Rejoin text that we split up below
   let text = splitKeys.map(i => items['text' + i]).filter(t => t).join();
+  if(text === editor.innerHTML) {
+    return;
+  }
   editor.innerHTML = text;
 }
 


### PR DESCRIPTION
cursor position was resetting when setting innerHTML. Checking equality before setting innerHTML prevents unnecessary update/reset.